### PR TITLE
ci: move to PR-only workflow with auto-README updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - 'README.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
 
 permissions: {}
 
@@ -18,18 +22,8 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       # These are not required step, but CI can be faster with cache
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -51,10 +45,4 @@ jobs:
         with:
           tool: hyperfine
 
-      - run: pnpm run update-readme
-
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        with:
-          commit_message: 'chore: update benchmark results in README [skip ci]'
-          file_pattern: README.md
+      - run: pnpm run bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
-  benchmark:
-    name: Benchmark
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,70 @@
+name: Update README
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'pnpm-lock.yaml'
+
+permissions: {}
+
+concurrency:
+  group: update-readme
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update README
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: outline/outline
+          path: bench-js-no-embedded/data
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: storybookjs/storybook
+          path: bench-mixed-embedded/data
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: continuedev/continue
+          path: bench-full-features/data
+
+      - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
+
+      - uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        with:
+          tool: hyperfine
+
+      - run: pnpm run update-readme
+
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        id: cpr
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: auto/update-readme
+          delete-branch: true
+          title: 'chore: update benchmark results in README'
+          commit-message: 'chore: update benchmark results in README'
+          body: Automated benchmark results update triggered by a change to `pnpm-lock.yaml`.
+          add-paths: README.md
+
+      - if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge --squash --auto --delete-branch "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
## Summary

- Drops direct pushes to `main` from CI entirely. The README auto-update now lands through a PR with squash auto-merge, matching the org `pull_request` ruleset.
- Splits the flow into two workflows:
  - **`ci.yml`** — runs benchmarks on PRs and on push-to-main for visibility, no push-back. Skips when the change is README-only.
  - **`update-readme.yml`** — triggers only when `pnpm-lock.yaml` lands on main (formatter version bumps). Regenerates the README and opens an auto-merging PR via `peter-evans/create-pull-request`.
- Shrinks the App-token blast radius: the token is now minted only inside `update-readme.yml`, never on PR runs of `ci.yml`.

## Follow-up

- Remove the `Benchmark` entry from `required_status_checks` on repo ruleset `9243389` so README-only auto-PRs aren't blocked waiting for a check that's been skipped via `paths-ignore`.