### PR TITLE
ci: use git clone for storybook checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,10 @@ jobs:
           persist-credentials: false
           repository: outline/outline
           path: bench-js-no-embedded/data
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          repository: storybookjs/storybook
-          path: bench-mixed-embedded/data
+      # storybookjs/storybook's default branch contains gitlinks under .external/
+      # without a .gitmodules file, which makes actions/checkout's post-job
+      # submodule cleanup fail. Use a plain shallow clone instead.
+      - run: git clone --depth=1 https://github.com/storybookjs/storybook.git bench-mixed-embedded/data
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false


### PR DESCRIPTION
## Summary

- `actions/checkout` of `storybookjs/storybook` started failing on 2026-04-30 with `fatal: No url found for submodule path '.external/addon-svelte-csf' in .gitmodules`.
- Storybook's `next` branch (its default) contains gitlinks under `.external/` but ships no `.gitmodules`, so `git submodule foreach --recursive` in actions/checkout's post-job auth cleanup blows up — even with `submodules: false`.
- Replace that single checkout step with a plain `git clone --depth=1`, mirroring what `init.sh` does locally. The other two external checkouts (outline, continue) are unaffected.

This will unblock #120 and the other renovate PRs that have been failing since 2026-04-30.