### PR TITLE
ci: use voidzero-dev/setup-vp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths-ignore:
-      - 'README.md'
+      - "README.md"
   push:
     branches:
       - main
     paths-ignore:
-      - 'README.md'
+      - "README.md"
 
 permissions: {}
 
@@ -43,10 +43,12 @@ jobs:
           repository: continuedev/continue
           path: bench-full-features/data
 
-      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
+      - uses: voidzero-dev/setup-vp@40646972e9ea5e33609c1bb31ac6a27fb01b641e # v1.10.0
+        with:
+          cache: true
 
       - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
         with:
           tool: hyperfine
 
-      - run: pnpm run bench
+      - run: vp run bench

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'pnpm-lock.yaml'
+      - "pnpm-lock.yaml"
 
 permissions: {}
 
@@ -49,13 +49,15 @@ jobs:
           repository: continuedev/continue
           path: bench-full-features/data
 
-      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
+      - uses: voidzero-dev/setup-vp@40646972e9ea5e33609c1bb31ac6a27fb01b641e # v1.10.0
+        with:
+          cache: true
 
       - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
         with:
           tool: hyperfine
 
-      - run: pnpm run update-readme
+      - run: vp run update-readme
 
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         id: cpr
@@ -63,8 +65,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           branch: auto/update-readme
           delete-branch: true
-          title: 'chore: update benchmark results in README'
-          commit-message: 'chore: update benchmark results in README'
+          title: "chore: update benchmark results in README"
+          commit-message: "chore: update benchmark results in README"
           body: Automated benchmark results update triggered by a change to `pnpm-lock.yaml`.
           add-paths: README.md
 

--- a/bench-all-and-update-readme.mjs
+++ b/bench-all-and-update-readme.mjs
@@ -9,7 +9,7 @@ const execAsync = promisify(exec);
 async function runBenchmark() {
   console.log("Running benchmark...");
   try {
-    const { stdout } = await execAsync("pnpm run bench");
+    const { stdout } = await execAsync("vp run bench");
     return stdout;
   } catch (error) {
     console.error("Error running benchmark:", error);
@@ -37,9 +37,9 @@ async function getVersions() {
   console.log("Fetching versions...");
   try {
     const [prettier, biome, oxfmt] = await Promise.all([
-      execAsync("pnpm prettier --version"),
-      execAsync("pnpm biome --version"),
-      execAsync("pnpm oxfmt --version"),
+      execAsync("vp exec prettier --version"),
+      execAsync("vp exec biome --version"),
+      execAsync("vp exec oxfmt --version"),
     ]);
 
     return {


### PR DESCRIPTION
Switch CI to [`voidzero-dev/setup-vp`](https://github.com/voidzero-dev/setup-vp) now that the project is on Vite+.

- `ci.yml` and `update-readme.yml`: replace `oxc-project/setup-node` with `setup-vp` (`cache: true`, auto-runs `vp install`)
- `pnpm run bench` / `pnpm run update-readme` → `vp run …`
- `bench-all-and-update-readme.mjs`: internal `pnpm` calls switched to `vp` (`vp run bench`, `vp exec prettier|biome|oxfmt --version`) so version reporting no longer relies on bare `pnpm` being on PATH

Benchmark subjects (prettier/biome/oxfmt) and hyperfine setup are unchanged.